### PR TITLE
Implement pagination for repository drawer

### DIFF
--- a/app/repos/RepoDrawer.tsx
+++ b/app/repos/RepoDrawer.tsx
@@ -16,9 +16,15 @@ import {
   Stack,
 } from "@chakra-ui/react";
 import { useSessionContext } from "@/context/useSessionContext";
-import getRepos from "@/utils/github/getRepos";
+import { getPaginatedRepos } from "@/utils/github/getRepos";
 
 //components
+type PageInfo = {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string;
+  endCursor: string;
+};
 
 const RepoDrawer = () => {
   const { isOpen, onOpen, onClose } = useDisclosure({
@@ -26,6 +32,8 @@ const RepoDrawer = () => {
   });
   const { repo, methods, session, user, repoWindowOpen } = useSessionContext();
   const [repos, setRepos] = useState<any[]>([]);
+  const [reposCount, setReposCount] = useState<number>(0);
+  const [pageInfo, setPageInfo] = useState<PageInfo | null>(null);
   const [filter, setFilter] = useState<string>("");
   const btnRef = useRef<any>();
 
@@ -37,15 +45,48 @@ const RepoDrawer = () => {
   useEffect(() => {
     if (!session) return;
     if (repos.length > 0) return;
+    if (!session?.provider_token) return;
 
-    getRepos(session?.provider_token)
+    getPaginatedRepos(session?.provider_token)
       .then((allRepos) => {
-        setRepos(allRepos);
+        if (allRepos?.nodes?.length) {
+          setRepos(allRepos.nodes);
+          setReposCount(allRepos.totalCount);
+          setPageInfo(allRepos.pageInfo);
+        }
       })
       .catch((err) => {
         console.log("Failed to get repos:", { err });
       });
-  }, [user, session]);
+  }, [repos.length, session, user]);
+
+  const onPreviousPage = async () =>
+    session?.provider_token &&
+    getPaginatedRepos(session?.provider_token, pageInfo?.endCursor)
+      .then((allRepos) => {
+        if (allRepos?.nodes?.length) {
+          setRepos(allRepos.nodes);
+          console.log(allRepos.pageInfo);
+          setPageInfo(allRepos.pageInfo);
+        }
+      })
+      .catch((err) => {
+        console.log("Failed to get repos:", { err });
+      });
+
+  const onNextPage = async () =>
+    session?.provider_token &&
+    getPaginatedRepos(session?.provider_token, null, pageInfo?.endCursor)
+      .then((allRepos) => {
+        if (allRepos?.nodes?.length) {
+          setRepos(allRepos.nodes);
+          console.log(allRepos.pageInfo);
+          setPageInfo(allRepos.pageInfo);
+        }
+      })
+      .catch((err) => {
+        console.log("Failed to get repos:", { err });
+      });
 
   if (!user) {
     return null;
@@ -62,11 +103,14 @@ const RepoDrawer = () => {
         <DrawerOverlay />
         <DrawerContent>
           <DrawerCloseButton />
-          <DrawerHeader>Select a repo</DrawerHeader>
+          <DrawerHeader>
+            Select a repo{reposCount ? ` (${reposCount})` : ""}
+          </DrawerHeader>
           <DrawerBody>
             {repos?.length > 0 ? (
               <>
                 <Input
+                  className="mb-2"
                   placeholder="Search repos"
                   value={filter}
                   onChange={(e) => {
@@ -129,7 +173,22 @@ const RepoDrawer = () => {
               </Stack>
             )}
           </DrawerBody>
-          <DrawerFooter />
+          {(pageInfo?.hasPreviousPage || pageInfo?.hasNextPage) && (
+            <DrawerFooter className="gap-2">
+              <>
+                {pageInfo.hasPreviousPage && (
+                  <Button size="sm" variant="outline" onClick={onPreviousPage}>
+                    Previous
+                  </Button>
+                )}
+                {pageInfo.hasNextPage && (
+                  <Button size="sm" variant="outline" onClick={onNextPage}>
+                    Next
+                  </Button>
+                )}
+              </>
+            </DrawerFooter>
+          )}
         </DrawerContent>
       </Drawer>
     </>

--- a/utils/github/getRepos.ts
+++ b/utils/github/getRepos.ts
@@ -33,4 +33,75 @@ const getRepos = async (access_token: any) => {
   }
 };
 
+export const getPaginatedRepos = async (
+  access_token: string,
+  before?: string | null,
+  after?: string
+) => {
+  if (!access_token) return console.error("Error: No access token provided");
+
+  // Define the GitHub API GraphQL URL for user repositories
+  const graphql_api_url = "https://api.github.com/graphql";
+
+  // Set up headers with the access token for authentication
+  const headers = {
+    Authorization: `Bearer ${access_token}`,
+    "Content-Type": "application/json",
+  };
+
+  // Set up GraphQL query with a max of 30 items per page
+  const query = `query {
+    viewer {
+      repositories(first: 30, orderBy: {field: NAME, direction: ASC}, isFork: false${
+        before ? `,before: "${before}"` : ""
+      }${after ? `,after: "${after}"` : ""}) {
+      nodes {
+        name
+        owner {
+          login
+        }
+      }
+      pageInfo {
+        hasNextPage 
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      }
+    }
+    }
+    `;
+
+  try {
+    // Make a GET request to the GitHub API
+    const response = await fetch(graphql_api_url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ query }),
+    });
+
+    // Parse the JSON response to get the list of repositories
+    const repositories: {
+      data: {
+        viewer: {
+          repositories: {
+            nodes: { name: string; owner: { login: string } }[];
+            pageInfo: {
+              hasNextPage: boolean;
+              hasPreviousPage: boolean;
+              startCursor: string;
+              endCursor: string;
+            };
+            totalCount: number;
+          };
+        };
+      };
+    } = await response.json();
+    return repositories.data.viewer.repositories;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 export default getRepos;


### PR DESCRIPTION
## Description

Because the GitHub API returns by default 30 items only - and because REST APIs are stateless - we could fetch user repositories from the GraphQL API just for this component. 

This PR provide "Previous" and "Next" buttons in the drawer as well as the number of total repositories in the title.

Follow-up of issue https://github.com/devgpt-labs/devgpt-releases/issues/125

## Screenshots

![image](https://github.com/devgpt-labs/devgpt-releases/assets/48206778/ec5eb962-b9b0-4b05-b403-9309d4211fe0)

![image](https://github.com/devgpt-labs/devgpt-releases/assets/48206778/9ea63b8c-e2e4-4cc4-81f9-918d4caaaf26)

![image](https://github.com/devgpt-labs/devgpt-releases/assets/48206778/1adb514b-1f9e-4966-96c6-b6cd97bd0913)
