### PR TITLE
[Bug] Remove filter of forked repos

### DIFF
--- a/utils/github/getRepos.ts
+++ b/utils/github/getRepos.ts
@@ -17,7 +17,7 @@ export const getPaginatedRepos = async (
   // Set up GraphQL query with a max of 30 items per page
   const query = `query {
     viewer {
-      repositories(first: 30, orderBy: {field: NAME, direction: ASC}, isFork: false${
+      repositories(first: 30, orderBy: {field: NAME, direction: ASC} ${
         before ? `,before: "${before}"` : ""
       }${after ? `,after: "${after}"` : ""}) {
       nodes {


### PR DESCRIPTION
**Description:** Forked repos are being suppressed from the query and thus are not showing to endusers in the repo drawer